### PR TITLE
Upgrade to timbre 6.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url  "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.11.0" :scope "provided"]
                  [com.fzakaria/slf4j-timbre "0.3.21"]
-                 [com.taoensso/timbre "5.2.1"]
+                 [com.taoensso/timbre "6.6.1"]
                  [de.active-group/active-clojure "0.40.0"]
                  [de.active-group/active-quickcheck "0.8.0"]
                  [de.active-group/timbre-riemann "0.2.1"]

--- a/src/active/clojure/logger/timbre.clj
+++ b/src/active/clojure/logger/timbre.clj
@@ -3,8 +3,8 @@
             [taoensso.encore :as encore]
             [taoensso.timbre :as timbre]
             [taoensso.timbre.appenders.core :as timbre-appenders]
-            [taoensso.timbre.appenders.3rd-party.rotor :as timbre-rotor]
-            [taoensso.timbre.appenders.3rd-party.logstash :as timbre-logstash]
+            [taoensso.timbre.appenders.community.rotor :as timbre-rotor]
+            [taoensso.timbre.appenders.community.logstash :as timbre-logstash]
 
             [active.clojure.condition :as c]
             [active.clojure.config :as config]


### PR DESCRIPTION
Timbre 6 has changed the namespaces of the 3rd library appenders.

(Needed to use the newer versions of 'Sente Websockets', which depend on Timbre 6)
